### PR TITLE
Add event detail modal with backend fetch

### DIFF
--- a/src/components/UpcomingEvents.jsx
+++ b/src/components/UpcomingEvents.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import '../pages/agendamento/agendamento.css';
+
+function UpcomingEvents({ eventos, onSelecionar }) {
+  if (!eventos || eventos.length === 0) {
+    return null;
+  }
+
+  const agora = new Date();
+  const proximos = eventos
+    .filter((e) => new Date(`${e.data}T${e.hora}`) >= agora)
+    .sort((a, b) => new Date(`${a.data}T${a.hora}`) - new Date(`${b.data}T${b.hora}`))
+    .slice(0, 5);
+
+  return (
+    <div className="lista-agendamentos">
+      <h3>Próximos agendamentos</h3>
+      {proximos.map((ag) => (
+        <div key={ag.id} className="agendamento" onClick={() => onSelecionar(ag.id)}>
+          <div className="agendamento-info">
+            <p><strong>{ag.titulo}</strong></p>
+            <p>{new Date(ag.data).toLocaleDateString('pt-BR')} {ag.hora}</p>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default UpcomingEvents;

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,0 +1,9 @@
+const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:3001';
+
+export async function fetchAgendamentoById(id) {
+  const response = await fetch(`${API_URL}/agendamentos/${id}`);
+  if (!response.ok) {
+    throw new Error('Falha ao buscar agendamento');
+  }
+  return response.json();
+}


### PR DESCRIPTION
## Summary
- add utility to fetch agendamento information
- list upcoming events and allow clicking them
- enable clicking events on calendar to view details

## Testing
- `npm test --silent` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_685b4eab24cc832eaf3de83d787d7af4